### PR TITLE
Feat: add invention, like, comment props for db

### DIFF
--- a/Useless Inventions/Data/ApplicationDbContext.cs
+++ b/Useless Inventions/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Useless_Inventions.Models;
 
 namespace Useless_Inventions.Data
 {
@@ -8,6 +9,46 @@ namespace Useless_Inventions.Data
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options)
         {
+        }
+
+        public DbSet<Invention> Inventions { get; set; }
+        public DbSet<Comment> Comments { get; set; }
+        public DbSet<Like> Likes { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            base.OnModelCreating(builder);
+
+            // Configure relationships and constraints
+            builder.Entity<Invention>()
+                .HasOne(i => i.User)
+                .WithMany()
+                .HasForeignKey(i => i.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Entity<Comment>()
+                .HasOne(c => c.User)
+                .WithMany()
+                .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Comment>()
+                .HasOne(c => c.Invention)
+                .WithMany(i => i.Comments)
+                .HasForeignKey(c => c.InventionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Entity<Like>()
+                .HasOne(l => l.User)
+                .WithMany()
+                .HasForeignKey(l => l.UserId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Like>()
+                .HasOne(l => l.Invention)
+                .WithMany(i => i.Likes)
+                .HasForeignKey(l => l.InventionId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/Useless Inventions/Data/ApplicationDbContext.cs
+++ b/Useless Inventions/Data/ApplicationDbContext.cs
@@ -20,35 +20,45 @@ namespace Useless_Inventions.Data
             base.OnModelCreating(builder);
 
             // Configure relationships and constraints
+            // Ensure that the UserId in the Invention table is not nullable
             builder.Entity<Invention>()
                 .HasOne(i => i.User)
                 .WithMany()
                 .HasForeignKey(i => i.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            // Ensure that the InventionId in the Comment table is not nullable
             builder.Entity<Comment>()
                 .HasOne(c => c.User)
                 .WithMany()
                 .HasForeignKey(c => c.UserId)
                 .OnDelete(DeleteBehavior.NoAction);
 
+            // Ensure that the InventionId in the Comment table is not nullable
             builder.Entity<Comment>()
                 .HasOne(c => c.Invention)
                 .WithMany(i => i.Comments)
                 .HasForeignKey(c => c.InventionId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            // Ensure that the UserId in the Comment table is not nullable
             builder.Entity<Like>()
                 .HasOne(l => l.User)
                 .WithMany()
                 .HasForeignKey(l => l.UserId)
                 .OnDelete(DeleteBehavior.NoAction);
 
+            // Ensure that the UserId in the Like table is not nullable
             builder.Entity<Like>()
                 .HasOne(l => l.Invention)
                 .WithMany(i => i.Likes)
                 .HasForeignKey(l => l.InventionId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            // Make sure that a user can only like an invention once
+            builder.Entity<Like>()  
+                .HasIndex(l => new { l.UserId, l.InventionId })  
+                .IsUnique();  
         }
     }
 }

--- a/Useless Inventions/Models/Comment.cs
+++ b/Useless Inventions/Models/Comment.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+
+namespace Useless_Inventions.Models;
+
+public class Comment
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Content { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
+    // Navigation properties
+    public int InventionId { get; set; }
+    public Invention Invention { get; set; } = null!;
+
+    public string UserId { get; set; } = string.Empty;
+    public IdentityUser User { get; set; } = null!;
+}

--- a/Useless Inventions/Models/Invention.cs
+++ b/Useless Inventions/Models/Invention.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+
+namespace Useless_Inventions.Models;
+
+public class Invention
+{
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    public string Description { get; set; } = string.Empty;
+
+    public string? ImageUrl { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
+    // Navigation properties
+    public string UserId { get; set; } = string.Empty;
+    public IdentityUser User { get; set; } = null!;
+    
+    public ICollection<Comment> Comments { get; set; } = new List<Comment>();
+    public ICollection<Like> Likes { get; set; } = new List<Like>();
+}

--- a/Useless Inventions/Models/Like.cs
+++ b/Useless Inventions/Models/Like.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Useless_Inventions.Models;
+
+public class Like
+{
+    public int Id { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    // Navigation properties
+    public int InventionId { get; set; }
+    public Invention Invention { get; set; } = null!;
+
+    public string UserId { get; set; } = string.Empty;
+    public IdentityUser User { get; set; } = null!;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for inventions, comments, and likes, enabling users to create inventions, comment on them, and like them.
	- Each invention now displays its associated comments and likes.
	- Users can only like a specific invention once.
- **Bug Fixes**
	- Ensured proper handling and validation of relationships between users, inventions, comments, and likes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->